### PR TITLE
Consume more events on bind

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,15 @@ export class Client {
       this.client.on("connectError", (err) => {
         reject(err);
       });
+      this.client.on("connectTimeout", (err) => {
+        reject(err);
+      });
+      this.client.on("connectRefused", (err) => {
+        reject(err);
+      });
+      this.client.on("error", (err) => {
+        reject(err);
+      });
 
       const user = input?.user ?? this.config.user;
       const pass = input?.pass ?? this.config.pass;


### PR DESCRIPTION
in cases of ssl handshake errors, dns resolution, connection refused the reject was not getting called on bind.

https://github.com/ldapjs/node-ldapjs/blob/master/lib/client/client.js#L1034-L1038